### PR TITLE
Update Docker setup for polarflare service

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2017-2022 Andrew Paglusch
+Copyright (c) 2017-2024 Andrew Paglusch
+Copyright (c) 2024 Polarnova
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,13 @@
 version: "latest"
 services:
-  flashpaper:
-    image: polarflare
+  polarflare:
+    image: ghcr.io/polarnova/polarflare:latest
     container_name: polarflare
     restart: always
     volumes:
-      - './data:/var/www/html/data'
+      - './data:/var/www/html/data/polarflare'
     ports:
-      - '8080:80'
+      - '8081:80'
     environment:
       SITE_TITLE: "PolarFlare :: Self-Destructing Message"
       SITE_LOGO: "img/logo_pf.svg"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,6 +19,6 @@ RUN rm -rf /var/www/html/docker && \
     chown -R nginx:nginx /var/run/ && \
     chmod +x /entrypoint.sh
 
-VOLUME /var/www/html/data
+VOLUME /var/www/html/data/polarflare
 
 ENTRYPOINT ["/bin/ash", "/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,21 +1,21 @@
 #!/usr/bin/env ash
 
 # Start php-fpm and nginx
-chown -R nginx: /var/www/html/data/
-touch /var/www/html/data/index.php
+chown -R nginx: /var/www/html/data/polarflare/
+touch /var/www/html/data/polarflare/index.php
 php-fpm83
 nginx -c /etc/nginx/nginx.conf
 
 # Ready to serve?
 for i in 1 2 3; do
-  echo "Checking to see if FlashPaper is ready. ($i of 3)"
-  curl -sm3 localhost | grep -q "AndrewPaglusch/FlashPaper"
+  echo "Checking to see if PolarFlare is ready. ($i of 3)"
+  curl -sm3 localhost | grep -q "Polarnova/PolarFlare"
   if [[ $? -eq 0 ]]; then
-    echo "FlashPaper is ready."
+    echo "PolarFlare is ready."
     break
   fi
   sleep 2
-  echo "FlashPaper is not ready."
+  echo "PolarFlare is not ready."
 done
 
 echo "Access logging is disabled for production use. Tailing error logs..."


### PR DESCRIPTION
## Summary
- rename service to `polarflare` and reference ghcr image
- map data subfolder `data/polarflare`
- update port mapping to `8081:80`
- adjust Dockerfile volume path
- update entrypoint script for new paths and name
- update license year and current author

## Testing
- `sh -n docker/entrypoint.sh`

------
https://chatgpt.com/codex/tasks/task_e_6874362397708333b1c23a4f2825bf55